### PR TITLE
Add command arguments to specify the Security Projects folder

### DIFF
--- a/SecurityReport.py
+++ b/SecurityReport.py
@@ -354,7 +354,7 @@ class SecurityReport:
 
         #Highlights
         from report_creation_utils import xml_utils
-        highlights_file_path = os.path.join(variables.CURRENT_DIR, variables.HISTORY_FOLDER_NAME, variables.HIGHLIGHTS_FILE_NAME)
+        highlights_file_path = os.path.join(variables.SECURITY_PROJECTS_DIRPATH, variables.HISTORY_FOLDER_NAME, variables.HIGHLIGHTS_FILE_NAME)
         monthly_highlights = xml_utils.get_element_value(highlights_file_path, 'MonthlyHighlights')
         highlighted_risks = xml_utils.get_element_value(highlights_file_path, 'HighlightedRisks')
         problems_identified = xml_utils.get_element_value(highlights_file_path, 'ProblemsIdentified')
@@ -367,7 +367,7 @@ class SecurityReport:
         # Open the SecurityReport Templates
         from xml.dom import minidom
         import variables
-        path = os.path.join('.',  variables.TEMPLATES_FOLDER_NAME, variables.SECURITY_REPORT_TEMPLATE_FILE_NAME)
+        path = os.path.join(os.path.dirname(__file__),  variables.TEMPLATES_FOLDER_NAME, variables.SECURITY_REPORT_TEMPLATE_FILE_NAME)
         xml_dom = minidom.parse(path)
 
         from report_creation_utils import xml_utils
@@ -402,7 +402,7 @@ class SecurityReport:
         # Encode the str result to bytes in order to write it to a file.
         result = xml_dom.toxml().encode('utf-8')
         # Save the Security Report in a file.
-        security_report_path = os.path.join(variables.CURRENT_DIR,  variables.HISTORY_FOLDER_NAME, str(self.report_date) + variables.SECURITY_REPORT_FILE_NAME)
+        security_report_path = os.path.join(variables.SECURITY_PROJECTS_DIRPATH,  variables.HISTORY_FOLDER_NAME, str(self.report_date) + variables.SECURITY_REPORT_FILE_NAME)
         file_handle = open(security_report_path, "wb")
         file_handle.write(result)
         file_handle.close()

--- a/createdata.py
+++ b/createdata.py
@@ -192,8 +192,8 @@ def populate_objects_array():
     '''
     iot_objects_array = []
 
-    # for dirpath, dirnames in os.walk(variables.CURRENT_DIR):
-    for dirpath, dirnames, files in os.walk(variables.CURRENT_DIR):
+    # for dirpath, dirnames in os.walk(variables.SECURITY_PROJECTS_DIRPATH):
+    for dirpath, dirnames, files in os.walk(variables.SECURITY_PROJECTS_DIRPATH):
 
         for dirname in dirnames:
             # Add all "Not Evaluated" Objects to the result Array

--- a/report_creation_utils/xml_utils.py
+++ b/report_creation_utils/xml_utils.py
@@ -1,8 +1,6 @@
 '''
 Xml file Helpers functions to read and write files, access elements or attributes.
 '''
-import os.path
-import variables
 
 def get_element_value(xml_file, element_tag_name):
     '''Return the value of the first element that has the 'element_tag_name' type item in the

--- a/variables.py
+++ b/variables.py
@@ -4,8 +4,8 @@ Define the variables in a module.
 
 """
 
-#CURRENT_DIR = 'C:\\Remi\\Orange Pro\\Suivi de Securite des Projets OCP'
-CURRENT_DIR = '/Users/Shosta/OrangePro/Suivi de Securite des Projets OCP'
+SECURITY_PROJECTS_DIRPATH = 'C:\\Remi\\Orange Pro\\Suivi de Securite des Projets OCP'
+#SECURITY_PROJECTS_DIRPATH = '/Users/Shosta/OrangePro/Suivi de Securite des Projets OCP'
 
 TEMPLATES_FOLDER_NAME = 'Templates'
 SECURITY_REPORT_TEMPLATE_FILE_NAME = 'SecurityReportTemplate.xml'

--- a/writereport.py
+++ b/writereport.py
@@ -3,29 +3,81 @@
 Write the eIoT report automatically based on the files in the directory tree.
 """
 
+import sys
+import getopt
 import createdata
 import SecurityReport
 import writexlsxreport
 import writepptreport
 
 
-def main():
-    """The main function that is launched when the program is started."""
+def usage():
+    '''
+    Display the awaited command and arguments for the 'writereport.py'.
+    '''
+    print('Here is the default usage of that command:')
+    print('writereport.py -s <security_projects_folder>')
+    print('If no source folder is specified, the default source folder is the '
+          'current folder.')
 
+
+def __get_security_projects_folder(argv):
+    '''
+    Get the Security Project folder from the command argument.
+    The Security Project folder is the folder that contains all the information about the objects
+    that are stored in subfolders.
+
+    Params:
+    argv the command arguments
+
+    Return: The value that comes after the -s or --security_projects_folder command argument.
+    '''
+    import variables
+    # Add default value.
+    security_projects_folder = variables.SECURITY_PROJECTS_DIRPATH
+    try:
+        opts, args = getopt.getopt(argv, "h:s:", ["help=", "security_projects_folder="])
+    except getopt.GetoptError:
+        print('Type \'writereport.py -h\' for help.')
+        sys.exit(2)
+
+    if opts.__len__() == 0:
+        usage()
+
+    for opt, arg in opts:
+        if opt == '-h':
+            usage()
+            sys.exit()
+        elif opt in ("-s", "--security_projects_folder"):
+            security_projects_folder = arg
+            variables.SECURITY_PROJECTS_DIRPATH = arg
+
+    return security_projects_folder
+
+
+def main(argv):
+    """The main function that is launched when the program is started."""
+    # Get folder argument from the command.
+    security_projects_folder = __get_security_projects_folder(argv)
+
+    # Populate the IoTObjects list with the info from the Security Projects folder.
     iot_objects_array = createdata.populate_objects_array()
 
      # Create the security report.
     security_report = SecurityReport.SecurityReport()
     security_report.populate_member_values(iot_objects_array)
 
+    # Write the Security report.
     writexlsxreport.write_excel_file_from(
+        security_projects_folder,
         'Rapport de Suivi de Sécurité des Objets Connectés.xlsx',
         iot_objects_array)
 
-    # Create the security report.
+    # Create the Security dashboard.
     security_report = SecurityReport.SecurityReport()
     security_report.populate_member_values(iot_objects_array)
     writepptreport.write_dashboard_file(
+        security_projects_folder,
         'Dashboard de Suivi de Sécurité des Objets Connectés.pptx',
         security_report)
 
@@ -34,5 +86,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])
     print("Reports writing done")

--- a/writexlsxreport.py
+++ b/writexlsxreport.py
@@ -246,7 +246,7 @@ def write_object_counter_to_report(excel_sheet, excel_workbook, iot_objects_arra
         bold, ' ' + str(objects_counter_dictionnary[variables.NOT_EVALUATED_PHASE]))
 
 
-def write_excel_file_from(file_name, iot_objects_array):
+def write_excel_file_from(security_projects_folder, file_name, iot_objects_array):
     """Write an Excel file (xlsx) from an array of IoT  Dictionnary objects.
     It is going to write 4 sheets.
 
@@ -264,7 +264,7 @@ def write_excel_file_from(file_name, iot_objects_array):
     from datetime import datetime
     now = datetime.now()
     import os.path
-    xls_abs_path = os.path.join(variables.CURRENT_DIR,
+    xls_abs_path = os.path.join(security_projects_folder,
                                 variables.HISTORY_FOLDER_NAME,
                                 str(now.year) + "-" + str(now.month)+ " - " + file_name)
     workbook = xlsxwriter.Workbook(xls_abs_path)


### PR DESCRIPTION
I am adding a command argument to specify the Security Projects folder path.
It is specified in the command line after a '-s' or '--security-projects-folder' argument.
A '-h' argument is also available to know how the module works.