### PR TITLE
Add an "On Hold" state for an objet and write it to the Excel file

### DIFF
--- a/IoTProjectInfo.py
+++ b/IoTProjectInfo.py
@@ -112,7 +112,7 @@ class ObjectInfo:
 
     @security_phase_progress.setter
     def security_phase_progress(self, value):
-        '''It can be Not Started, In Progress, Done or Not Evaluated'''
+        '''It can be Not Started, In Progress, On Hold, Done or Not Evaluated'''
         self._security_phase_progress = value
 
     @is_b2b.setter

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Your folder hierarchy should be as followed :
 The directory of project and object must be described as followed : 
  "**_Phase - Project Name - Object Name_**"
 
- The Phase must be one of the following : 
+ The Phase **must** be one of the following : 
  * Done
  * In Progress
+ * On Hold
  * Not Started
  * Not Evaluated
 
@@ -83,6 +84,8 @@ Refresh the bash shell environment:
 
 If you use the fish shell, just type that command:
 >`alias writereport 'python3 /path/to/writereport.py'`
+
+or check the documentation [here](https://fishshell.com/docs/current/commands.html#alias).
 
 
 :books: Doc : Add explanation on how to create an alias on macOS

--- a/SecurityReport.py
+++ b/SecurityReport.py
@@ -319,6 +319,7 @@ class SecurityReport:
         # Security Progress
         not_started_counter = 0
         in_progress_counter = 0
+        on_hold_counter = 0
         done_counter = 0
         not_evaluated_counter = 0
 
@@ -333,7 +334,7 @@ class SecurityReport:
             # Object type : B2B or B2C
             if iot_object.is_b2b:
                 b2b_counter = b2b_counter + 1
-            if iot_object.is_b2c:
+            elif iot_object.is_b2c:
                 b2c_counter = b2c_counter + 1
 
             # Risks            
@@ -343,25 +344,27 @@ class SecurityReport:
 
             # Security Progress
             import variables
-            if iot_object.security_phase_progress == variables.NOT_STARTED_PHASE:
-                not_started_counter = not_started_counter + 1
-            if iot_object.security_phase_progress == variables.IN_PROGRESS_PHASE:
-                in_progress_counter = in_progress_counter + 1
             if iot_object.security_phase_progress == variables.DONE_PHASE:
                 done_counter = done_counter + 1
-            if iot_object.security_phase_progress == variables.NOT_EVALUATED_PHASE:
+            elif iot_object.security_phase_progress == variables.IN_PROGRESS_PHASE:
+                in_progress_counter = in_progress_counter + 1
+            elif iot_object.security_phase_progress == variables.ON_HOLD_PHASE:
+                on_hold_counter = on_hold_counter + 1
+            elif iot_object.security_phase_progress == variables.NOT_EVALUATED_PHASE:
                 not_evaluated_counter = not_evaluated_counter + 1
+            elif iot_object.security_phase_progress == variables.NOT_STARTED_PHASE:
+                not_started_counter = not_started_counter + 1
 
             # Delivery Security Phase
             if iot_object.delivery_security_process_phase == variables.EVALUATION_PHASE:
                 in_evaluation_counter = in_evaluation_counter + 1
-            if iot_object.delivery_security_process_phase == variables.QUALIFICATION_PHASE:
+            elif iot_object.delivery_security_process_phase == variables.QUALIFICATION_PHASE:
                 in_qualification_counter = in_qualification_counter + 1
-            if iot_object.delivery_security_process_phase == variables.SECURITY_AUDIT_PHASE:
+            elif iot_object.delivery_security_process_phase == variables.SECURITY_AUDIT_PHASE:
                 in_audit_counter = in_audit_counter + 1
-            if iot_object.delivery_security_process_phase == variables.TESTING_PHASE:
+            elif iot_object.delivery_security_process_phase == variables.TESTING_PHASE:
                 in_testing_counter = in_testing_counter + 1
-            if iot_object.delivery_security_process_phase == variables.IN_LIFE_PHASE:
+            elif iot_object.delivery_security_process_phase == variables.IN_LIFE_PHASE:
                 on_the_market_counter = on_the_market_counter + 1
 
         # Object type : B2B or B2C
@@ -374,7 +377,7 @@ class SecurityReport:
         self.risks.light_risks = light_risks_counter
         self.risks.riskiestobjects_list = self.__get_riskiestobjects_list(iot_objects_array)
 
-        #SecurityPhaseProgress : Not Started, In Progress, Done, Not Evaluated
+        #SecurityPhaseProgress : Not Started, In Progress, On Hold, Done, Not Evaluated
         self.security_phase_progress.not_started_objects = not_started_counter
         self.security_phase_progress.in_progress_objects = in_progress_counter
         self.security_phase_progress.done_objects = done_counter

--- a/createdata.py
+++ b/createdata.py
@@ -264,6 +264,14 @@ def populate_objects_array(security_projects_folder):
                     variables.IN_PROGRESS_PHASE)
                 iot_objects_array.append(iot_object)
 
+            # Add all "On Hold" Objects to the result Array
+            if dirname.lower().startswith(variables.ON_HOLD_PHASE.lower()):
+                iot_object = create_object_info(
+                    dirpath,
+                    dirname,
+                    variables.ON_HOLD_PHASE)
+                iot_objects_array.append(iot_object)
+
             # Add all "Done" Objects to the result Array
             if dirname.lower().startswith(variables.DONE_PHASE.lower()):
                 iot_object = create_object_info(

--- a/report_creation_utils/counters_utils.py
+++ b/report_creation_utils/counters_utils.py
@@ -70,6 +70,17 @@ def count_in_progress(iot_objects_array):
     return are_in_progress_counter
 
 
+def count_on_hold(iot_objects_array):
+    '''Return the number of ObjectInfo that are in a 'On Hold' step.'''
+    are_in_progress_counter = 0
+
+    for iot_object in iot_objects_array:
+        if iot_object.security_phase_progress == variables.ON_HOLD_PHASE:
+            are_in_progress_counter = are_in_progress_counter + 1
+
+    return are_in_progress_counter
+
+
 def count_done(iot_objects_array):
     '''Return the number of ObjectInfo that are in a 'Done' step.'''
     are_done_counter = 0

--- a/variables.py
+++ b/variables.py
@@ -27,6 +27,7 @@ IN_LIFE_PHASE = 'In Life'
 NOT_EVALUATED_PHASE = 'Not Evaluated'
 NOT_STARTED_PHASE = 'Not Started'
 IN_PROGRESS_PHASE = 'In Progress'
+ON_HOLD_PHASE = 'On Hold'
 DONE_PHASE = 'Done'
 
 SECURITY_MANAGER_NAME = 'Rémi Lavedrine'

--- a/writereport.py
+++ b/writereport.py
@@ -16,7 +16,7 @@ def usage():
     Display the awaited command and arguments for the 'writereport.py'.
     '''
     print('Here is the default usage of that command:')
-    print('writereport.py -s <security_projects_folder>')
+    print('> writereport.py -s /Path/to/your/security/projects/folder')
     print('If no source folder is specified, the default source folder is the '
           'current folder.')
 
@@ -35,8 +35,9 @@ def __get_security_projects_folder(argv):
     import variables
     # Add default value.
     security_projects_folder = variables.SECURITY_PROJECTS_DIRPATH
+    #return security_projects_folder # For Debugging purpose only.
+
     try:
-        print(argv)
         opts, args = getopt.getopt(argv, "hs:", ["help", "security_projects_folder="])
     except getopt.GetoptError:
         print('Type \'writereport.py -h\' for help.')

--- a/writexlsxreport.py
+++ b/writexlsxreport.py
@@ -69,6 +69,7 @@ def objects_phase_counter(iot_objects_array):
         variables.NOT_EVALUATED_PHASE: 0,
         variables.NOT_STARTED_PHASE: 0,
         variables.IN_PROGRESS_PHASE: 0,
+        variables.ON_HOLD_PHASE: 0,
         variables.DONE_PHASE: 0
     }
     for iot_object in iot_objects_array:
@@ -76,6 +77,8 @@ def objects_phase_counter(iot_objects_array):
             objects_count_dictionnary[variables.DONE_PHASE] = objects_count_dictionnary[variables.DONE_PHASE] + 1
         elif iot_object.security_phase_progress == variables.IN_PROGRESS_PHASE:
             objects_count_dictionnary[variables.IN_PROGRESS_PHASE] = objects_count_dictionnary[variables.IN_PROGRESS_PHASE] + 1
+        elif iot_object.security_phase_progress == variables.ON_HOLD_PHASE:
+            objects_count_dictionnary[variables.ON_HOLD_PHASE] = objects_count_dictionnary[variables.ON_HOLD_PHASE] + 1
         elif iot_object.security_phase_progress == variables.NOT_STARTED_PHASE:
             objects_count_dictionnary[variables.NOT_STARTED_PHASE] = objects_count_dictionnary[variables.NOT_STARTED_PHASE] + 1
         elif iot_object.security_phase_progress == variables.NOT_EVALUATED_PHASE:
@@ -138,7 +141,7 @@ def write_line_to_report(project_name_string,
     # Add format to the Object State row => Red, Amber, Green.
     if object_state_string == variables.NOT_STARTED_PHASE or object_state_string == variables.NOT_EVALUATED_PHASE:
         excel_sheet.write(row, column+3, object_state_string, red_bold)
-    elif object_state_string == variables.IN_PROGRESS_PHASE:
+    elif object_state_string == variables.IN_PROGRESS_PHASE or object_state_string == variables.ON_HOLD_PHASE:
         excel_sheet.write(row, column+3, object_state_string, orange_bold)
     elif object_state_string == variables.DONE_PHASE:
         excel_sheet.write(row, column+3, object_state_string, green_bold)
@@ -252,11 +255,16 @@ def write_object_counter_to_report(excel_sheet, excel_workbook, iot_objects_arra
 
     excel_sheet.write_rich_string(
         'K8',
+        underline, 'Nombre d\'objets à l\'état \'On Hold\':',
+        bold, ' ' + str(objects_counter_dictionnary[variables.ON_HOLD_PHASE]))
+
+    excel_sheet.write_rich_string(
+        'K10',
         underline, 'Nombre d\'objets à l\'état \'Not Started\':',
         bold, ' ' + str(objects_counter_dictionnary[variables.NOT_STARTED_PHASE]))
 
     excel_sheet.write_rich_string(
-        'K10',
+        'K12',
         underline, 'Nombre d\'objets à l\'état \'Not Evaluated\':',
         bold, ' ' + str(objects_counter_dictionnary[variables.NOT_EVALUATED_PHASE]))
 


### PR DESCRIPTION
A new phase is available for a project. It is "On Hold" as described in the #28 issue.
It describes when a project is blocked due to some external means.
We add it as a phase possibility for an object.
We described the appropriate project in each sheet of the Excel report file.
We add a global counter to access the number of "On Hold" projects.
We store these value in the Security Report as well (Security Report is here to store the data from one month to the other).