### PR TITLE
Store the "On Hold" counter on the Security Report xml file.

### DIFF
--- a/SecurityReport.py
+++ b/SecurityReport.py
@@ -92,14 +92,16 @@ class SecurityPhaseProgress:
 
     It is described with the following phases :
     1. Not Started
-    2. In Progress
-    3. Done
-    4. Not Evaluated
+    2. On Hold
+    3. In Progress
+    4. Done
+    5. Not Evaluated
     '''
 
     def __init__(self):
         # print('Delivery Phases')
         self._in_progress_objects = 0
+        self._on_hold_objects = 0
         self._done_objects = 0
         self._not_started_objects = 0
         self._not_evaluated_objects = 0
@@ -107,6 +109,10 @@ class SecurityPhaseProgress:
     @property
     def in_progress_objects(self):
         return self._in_progress_objects
+
+    @property
+    def on_hold_objects(self):
+        return self._on_hold_objects
 
     @property
     def done_objects(self):
@@ -123,6 +129,10 @@ class SecurityPhaseProgress:
     @in_progress_objects.setter
     def in_progress_objects(self, value):
         self._in_progress_objects = value
+
+    @on_hold_objects.setter
+    def on_hold_objects(self, value):
+        self._on_hold_objects = value
 
     @done_objects.setter
     def done_objects(self, value):
@@ -381,6 +391,7 @@ class SecurityReport:
         #SecurityPhaseProgress : Not Started, In Progress, On Hold, Done, Not Evaluated
         self.security_phase_progress.not_started_objects = not_started_counter
         self.security_phase_progress.in_progress_objects = in_progress_counter
+        self.security_phase_progress.on_hold_objects = on_hold_counter
         self.security_phase_progress.done_objects = done_counter
         self.security_phase_progress.not_evaluated_objects = not_evaluated_counter
 
@@ -426,6 +437,7 @@ class SecurityReport:
 
         # Replace the ObjectsPhases(=>SecurityPhaseProgress) childs attributes.
         xml_utils.replace_attribute_value(xml_dom, 'InProgressObjects', 'counter', str(self.security_phase_progress.in_progress_objects))
+        xml_utils.replace_attribute_value(xml_dom, 'OnHoldObjects', 'counter', str(self.security_phase_progress.on_hold_objects))
         xml_utils.replace_attribute_value(xml_dom, 'DoneObjects', 'counter', str(self.security_phase_progress.done_objects))
         xml_utils.replace_attribute_value(xml_dom, 'NotStartedObjects', 'counter', str(self.security_phase_progress.not_started_objects))
         xml_utils.replace_attribute_value(xml_dom, 'NotEvaluatedObjects', 'counter', str(self.security_phase_progress.not_evaluated_objects))

--- a/Templates/SecurityReportTemplate.xml
+++ b/Templates/SecurityReportTemplate.xml
@@ -9,6 +9,7 @@
         </SecurityPhases>
         <ObjectsPhases>
             <InProgressObjects counter=""></InProgressObjects>
+            <OnHoldObjects counter=""></OnHoldObjects>
             <DoneObjects counter=""></DoneObjects>
             <NotStartedObjects counter=""></NotStartedObjects>
             <NotEvaluatedObjects counter=""></NotEvaluatedObjects>

--- a/report_creation_utils/counters_utils.py
+++ b/report_creation_utils/counters_utils.py
@@ -72,13 +72,13 @@ def count_in_progress(iot_objects_array):
 
 def count_on_hold(iot_objects_array):
     '''Return the number of ObjectInfo that are in a 'On Hold' step.'''
-    are_in_progress_counter = 0
+    are_on_hold_counter = 0
 
     for iot_object in iot_objects_array:
         if iot_object.security_phase_progress == variables.ON_HOLD_PHASE:
-            are_in_progress_counter = are_in_progress_counter + 1
+            are_on_hold_counter = are_on_hold_counter + 1
 
-    return are_in_progress_counter
+    return are_on_hold_counter
 
 
 def count_done(iot_objects_array):

--- a/writepptreport.py
+++ b/writepptreport.py
@@ -19,6 +19,7 @@ def __get_preceding_securityprogress_counters():
     A Tuple that has the Security Progress counters in the following order, 
     Not started,
     In progresss,
+    On Hold,
     Done,
     Not evaluated
     '''
@@ -35,12 +36,14 @@ def __get_preceding_securityprogress_counters():
         
         are_notstarted_counter = xml_utils.get_attribute_value(last_month_security_report_path, 'NotStartedObjects', 'counter')
         are_inprogresss_counter = xml_utils.get_attribute_value(last_month_security_report_path, 'InProgressObjects', 'counter')
+        are_onhold_counter = xml_utils.get_attribute_value(last_month_security_report_path, 'OnHoldObjects', 'counter')
         are_done_counter = xml_utils.get_attribute_value(last_month_security_report_path, 'DoneObjects', 'counter')
         are_notevaluated_counter = xml_utils.get_attribute_value(last_month_security_report_path, 'NotEvaluatedObjects', 'counter')
         
         
         return [are_notstarted_counter,
                 are_inprogresss_counter,
+                are_onhold_counter,
                 are_done_counter,
                 are_notevaluated_counter]
 
@@ -52,10 +55,11 @@ def __form_securityprogress_chart_data(security_report):
 
     chart_data = ChartData()
     chart_data.categories = ['July', 'August']
-    chart_data.add_series('Done', (last_month_securityprogress_counters[0], security_report.security_phase_progress.done_objects))
     chart_data.add_series('In Progress', (last_month_securityprogress_counters[1], security_report.security_phase_progress.in_progress_objects))
-    chart_data.add_series('Not Started', (last_month_securityprogress_counters[2], security_report.security_phase_progress.not_started_objects))
-    chart_data.add_series('Not Eval.', (last_month_securityprogress_counters[3], security_report.security_phase_progress.not_evaluated_objects))
+    chart_data.add_series('On Hold', (last_month_securityprogress_counters[2]], security_report.security_phase_progress.on_hold_objects))
+    chart_data.add_series('Done', (last_month_securityprogress_counters[3], security_report.security_phase_progress.done_objects))
+    chart_data.add_series('Not Started', (last_month_securityprogress_counters[0], security_report.security_phase_progress.not_started_objects))
+    chart_data.add_series('Not Eval.', (last_month_securityprogress_counters[4], security_report.security_phase_progress.not_evaluated_objects))
 
     return chart_data
 
@@ -184,6 +188,11 @@ def __draw_riskiest_objects_linechart(slide, security_report):
     moderaterisks_chartserie = []
     lightrisks_chartserie = []
 
+    riskiest_objects_names = []
+    object_lambda = list(map(lambda n: riskiestobjects_list[n].object_name, range (5)))
+    m = object_lambda
+    
+    
     
     # We have less than 5 objects so we take every objets and display it.
     if (length < 5):


### PR DESCRIPTION
There is now a new "On Hold" phase for an object that means that this object is blocked due to some external factor.
I add it to the Data Model.
Then I store it in the SecurityReport xml template file. So that I can retreive it later on when I want to create the chart that describes the objects phase for this month and last month.
The chart is updated accordingly with a new bar that describes the "On Hold" objects in every Security phase ("Evaluation", "Qualification", "Delvery Request" or "In Life").