### PR TITLE
Store the eIoT counter on the Security Report xml file

### DIFF
--- a/SecurityReport.py
+++ b/SecurityReport.py
@@ -294,25 +294,30 @@ class SecurityReport:
     @eiot_objects_count.setter
     def eiot_objects_count(self, value):
         self._eiot_objects_count = value
+
     @b2c_objects_count.setter
     def b2c_objects_count(self, value):
         self._b2c_objects_count = value
 
     def __get_riskiestobjects_list(self, iot_objects_array):
         import variables
+        # We copy the iot_objects_array variables so that we can remove items from it without worrying.
+        import copy
+        removable_iot_objects_array = copy.deepcopy(iot_objects_array)
+
         # 1. remove all Evaluation Phase objects.
-        for iot_object in iot_objects_array:
+        for iot_object in removable_iot_objects_array:
             if iot_object.delivery_security_process_phase == variables.EVALUATION_PHASE:
-                 iot_objects_array.remove(iot_object)
+                 removable_iot_objects_array.remove(iot_object)
 
         #2. Sort the new array by Highest risk counter
-        iot_objects_array.sort(key=lambda iot:iot._high_risks_counter, reverse=True)
+        removable_iot_objects_array.sort(key=lambda iot:iot._high_risks_counter, reverse=True)
 
         #3. Get the five first objects
-        if len(iot_objects_array) < 5:
-            return iot_objects_array
+        if len(removable_iot_objects_array) < 5:
+            return removable_iot_objects_array
         else:
-            return iot_objects_array[:5]
+            return removable_iot_objects_array[:5]
 
 
     def populate_member_values(self, iot_objects_array):

--- a/SecurityReport.py
+++ b/SecurityReport.py
@@ -227,6 +227,7 @@ class SecurityReport:
         self._report_date = str(now.year) + "-" + str(now.month)
         self._total_objects_count = 0
         self._b2b_objects_count = 0
+        self._eiot_objects_count = 0
         self._b2c_objects_count = 0
 
 
@@ -259,6 +260,10 @@ class SecurityReport:
         return self._b2b_objects_count
 
     @property
+    def eiot_objects_count(self):
+        return self._eiot_objects_count
+
+    @property
     def b2c_objects_count(self):
         return self._b2c_objects_count
 
@@ -286,6 +291,9 @@ class SecurityReport:
     def b2b_objects_count(self, value):
         self._b2b_objects_count = value
 
+    @eiot_objects_count.setter
+    def eiot_objects_count(self, value):
+        self._eiot_objects_count = value
     @b2c_objects_count.setter
     def b2c_objects_count(self, value):
         self._b2c_objects_count = value
@@ -321,6 +329,7 @@ class SecurityReport:
         # Define the counters.
         # Object type : B2B or B2C
         b2b_counter = 0
+        eiot_counter = 0
         b2c_counter = 0
         # Risks
         high_risks_counter = 0
@@ -343,7 +352,9 @@ class SecurityReport:
 
         for iot_object in iot_objects_array:
             # Object type : B2B or B2C
-            if iot_object.is_b2b:
+            if iot_object.is_eiot:
+                eiot_counter = eiot_counter + 1
+            elif iot_object.is_b2b:
                 b2b_counter = b2b_counter + 1
             elif iot_object.is_b2c:
                 b2c_counter = b2c_counter + 1
@@ -378,11 +389,12 @@ class SecurityReport:
             elif iot_object.delivery_security_process_phase == variables.IN_LIFE_PHASE:
                 on_the_market_counter = on_the_market_counter + 1
 
-        # Object type : B2B or B2C
+        # Object type : B2B, EIOT or B2C
         self.b2b_objects_count = b2b_counter
+        self.eiot_objects_count = eiot_counter
         self.b2c_objects_count = b2c_counter
 
-        # Risks : High risks or Light risks
+        # Risks : High, Moderate or Light risks
         self.risks.high_risks = high_risks_counter
         self.risks.moderate_risks = moderate_risks_counter
         self.risks.light_risks = light_risks_counter
@@ -425,6 +437,7 @@ class SecurityReport:
         # Replace the SecurityReport node attributes.
         xml_utils.replace_attribute_value(xml_dom, 'SecurityReport', 'date', str(self.report_date))
         xml_utils.replace_attribute_value(xml_dom, 'SecurityReport', 'totalObjects', str(self.total_objects_count))
+        xml_utils.replace_attribute_value(xml_dom, 'SecurityReport', 'EIOTObjects', str(self.eiot_objects_count))
         xml_utils.replace_attribute_value(xml_dom, 'SecurityReport', 'B2BObjects', str(self.b2b_objects_count))
         xml_utils.replace_attribute_value(xml_dom, 'SecurityReport', 'B2CObjects', str(self.b2c_objects_count))
 

--- a/createdata.py
+++ b/createdata.py
@@ -239,6 +239,7 @@ def populate_objects_array(security_projects_folder):
     # for dirpath, dirnames in os.walk(variables.SECURITY_PROJECTS_DIRPATH):
     for dirpath, dirnames, files in os.walk(security_projects_folder):
 
+        dirnames.sort()
         for dirname in dirnames:
             # Add all "Not Evaluated" Objects to the result Array
             if dirname.lower().startswith(variables.NOT_EVALUATED_PHASE.lower()):


### PR DESCRIPTION
Store the eIoT counter on the Security Report xml file
and 
solve a bug about retrieving the riskiest objects.